### PR TITLE
Add placeholder managers and utilities

### DIFF
--- a/notifications.py
+++ b/notifications.py
@@ -1,0 +1,39 @@
+# -*- coding: utf-8 -*-
+"""Simple notification management placeholder."""
+
+import logging
+from datetime import datetime
+from typing import Any, Dict, List
+
+logger = logging.getLogger(__name__)
+
+_notifications: List[Dict[str, Any]] = []
+
+
+def add_notification(user_id: int, notification_type: str, title: str, message: str) -> None:
+    """Store a notification for a user."""
+    _notifications.append({
+        "user_id": user_id,
+        "type": notification_type,
+        "title": title,
+        "message": message,
+        "is_read": False,
+        "created_at": datetime.now(),
+    })
+
+
+def get_user_notifications(user_id: int) -> List[Dict[str, Any]]:
+    """Return notifications for the specified user."""
+    return [n for n in _notifications if n.get("user_id") == user_id]
+
+
+class NotificationManager:
+    def add_notification(self, user_id: int, notification_type: str, title: str, message: str) -> None:
+        add_notification(user_id, notification_type, title, message)
+
+    def get_user_notifications(self, user_id: int) -> List[Dict[str, Any]]:
+        return get_user_notifications(user_id)
+
+
+notification_manager = NotificationManager()
+

--- a/rental_manager.py
+++ b/rental_manager.py
@@ -1,0 +1,201 @@
+# -*- coding: utf-8 -*-
+"""Simplified rental management placeholder."""
+
+import logging
+from datetime import datetime, timedelta
+from typing import Any, Dict, List, Optional, Tuple
+
+from constants import Constants
+
+logger = logging.getLogger(__name__)
+
+# In-memory storage for rentals
+_rentals: Dict[int, Dict[str, Any]] = {}
+_next_id = 1
+
+
+def get_all_rentals() -> List[Dict[str, Any]]:
+    return list(_rentals.values())
+
+
+def get_rental_price(rank: int, tier: str) -> float:
+    """Return a rental price based on rank/tier."""
+    return float(Constants.get_price_for_rank(rank))
+
+
+def create_rental_request(user_id: int, keyword: str) -> Tuple[Optional[Dict[str, Any]], Optional[str]]:
+    """Create a new rental entry in pending state."""
+    global _next_id
+    rental = {
+        "id": _next_id,
+        "user_id": user_id,
+        "keyword": keyword,
+        "asset_id": None,
+        "asset_name": None,
+        "asset_type": None,
+        "rank": -1,
+        "tier": Constants.TIER_UNAVAILABLE,
+        "price": 0,
+        "status": Constants.RENTAL_STATUS_PENDING,
+    }
+    _rentals[_next_id] = rental
+    _next_id += 1
+    return rental, None
+
+
+def create_rental(data: Dict[str, Any]) -> int:
+    """Add a rental to the store and return its id."""
+    global _next_id
+    data = dict(data)
+    data.setdefault("id", _next_id)
+    _rentals[_next_id] = data
+    _next_id += 1
+    return data["id"]
+
+
+def get_rental(rental_id: int) -> Tuple[Optional[Dict[str, Any]], Optional[str]]:
+    rental = _rentals.get(rental_id)
+    if not rental:
+        return None, "rental not found"
+    return rental, None
+
+
+def activate_rental(rental_id: int, payment_id: str, duration_hours: int) -> Tuple[bool, str]:
+    rental = _rentals.get(rental_id)
+    if not rental:
+        return False, "rental not found"
+    rental["status"] = Constants.RENTAL_STATUS_ACTIVE
+    rental["payment_id"] = payment_id
+    rental["start_time"] = datetime.now()
+    rental["end_time"] = datetime.now() + timedelta(hours=duration_hours)
+    return True, ""
+
+
+def cancel_rental(rental_id: int) -> Tuple[bool, str]:
+    rental = _rentals.get(rental_id)
+    if not rental:
+        return False, "rental not found"
+    rental["status"] = Constants.RENTAL_STATUS_CANCELED
+    return True, ""
+
+
+def extend_rental(rental_id: int, payment_id: str, duration_hours: int) -> Tuple[bool, str]:
+    rental = _rentals.get(rental_id)
+    if not rental:
+        return False, "rental not found"
+    rental["end_time"] = rental.get("end_time", datetime.now()) + timedelta(hours=duration_hours)
+    rental["payment_id"] = payment_id
+    return True, ""
+
+
+def update_rental_status(rental_id: int, new_status: str) -> Tuple[bool, str]:
+    rental = _rentals.get(rental_id)
+    if not rental:
+        return False, "rental not found"
+    rental["status"] = new_status
+    return True, ""
+
+
+def get_rentals_by_status(status: str) -> List[Dict[str, Any]]:
+    return [r for r in _rentals.values() if r.get("status") == status]
+
+
+def get_rentals_expiring_soon(hours: int) -> List[Dict[str, Any]]:
+    upcoming = []
+    threshold = datetime.now() + timedelta(hours=hours)
+    for r in _rentals.values():
+        end_time = r.get("end_time")
+        if end_time and end_time <= threshold and r.get("status") in [
+            Constants.RENTAL_STATUS_ACTIVE,
+            Constants.RENTAL_STATUS_MONITORING,
+            Constants.RENTAL_STATUS_EXPIRING,
+        ]:
+            upcoming.append(r)
+    return upcoming
+
+
+async def expire_rental(rental_id: int) -> Tuple[bool, str]:
+    rental = _rentals.get(rental_id)
+    if not rental:
+        return False, "rental not found"
+    rental["status"] = Constants.RENTAL_STATUS_EXPIRED
+    return True, ""
+
+
+async def replace_rental_asset(rental_id: int, new_asset_id: int, rank: int, tier: str) -> Tuple[bool, str]:
+    rental = _rentals.get(rental_id)
+    if not rental:
+        return False, "rental not found"
+    rental["asset_id"] = new_asset_id
+    rental["rank"] = rank
+    rental["tier"] = tier
+    return True, ""
+
+
+async def get_suitable_asset_for_keyword(keyword: str) -> Tuple[Optional[Dict[str, Any]], Optional[str]]:
+    """Placeholder that returns None. Real implementation would query assets."""
+    return None, "not implemented"
+
+
+def archive_expired_rentals(days_threshold: int = 0) -> int:
+    count = 0
+    now = datetime.now() - timedelta(days=days_threshold)
+    for r in list(_rentals.values()):
+        end = r.get("end_time")
+        if end and end < now and r.get("status") in [Constants.RENTAL_STATUS_EXPIRED, Constants.RENTAL_STATUS_CANCELED]:
+            r["status"] = Constants.RENTAL_STATUS_ARCHIVED
+            count += 1
+    return count
+
+
+class RentalManager:
+    def get_all_rentals(self) -> List[Dict[str, Any]]:
+        return get_all_rentals()
+
+    def get_rentals_by_status(self, status: str) -> List[Dict[str, Any]]:
+        return get_rentals_by_status(status)
+
+    def get_rental_price(self, rank: int, tier: str) -> float:
+        return get_rental_price(rank, tier)
+
+    def create_rental_request(self, user_id: int, keyword: str) -> Tuple[Optional[Dict[str, Any]], Optional[str]]:
+        return create_rental_request(user_id, keyword)
+
+    def create_rental(self, data: Dict[str, Any]) -> int:
+        return create_rental(data)
+
+    def get_rental(self, rental_id: int) -> Tuple[Optional[Dict[str, Any]], Optional[str]]:
+        return get_rental(rental_id)
+
+    def activate_rental(self, rental_id: int, payment_id: str, duration_hours: int) -> Tuple[bool, str]:
+        return activate_rental(rental_id, payment_id, duration_hours)
+
+    def cancel_rental(self, rental_id: int) -> Tuple[bool, str]:
+        return cancel_rental(rental_id)
+
+    def extend_rental(self, rental_id: int, payment_id: str, duration_hours: int) -> Tuple[bool, str]:
+        return extend_rental(rental_id, payment_id, duration_hours)
+
+    def update_rental_status(self, rental_id: int, new_status: str) -> Tuple[bool, str]:
+        return update_rental_status(rental_id, new_status)
+
+    def get_rentals_expiring_soon(self, hours: int) -> List[Dict[str, Any]]:
+        return get_rentals_expiring_soon(hours)
+
+    async def expire_rental(self, rental_id: int) -> Tuple[bool, str]:
+        return await expire_rental(rental_id)
+
+    async def replace_rental_asset(self, rental_id: int, new_asset_id: int, rank: int, tier: str) -> Tuple[bool, str]:
+        return await replace_rental_asset(rental_id, new_asset_id, rank, tier)
+
+    async def get_suitable_asset_for_keyword(self, keyword: str) -> Tuple[Optional[Dict[str, Any]], Optional[str]]:
+        return await get_suitable_asset_for_keyword(keyword)
+
+    def archive_expired_rentals(self, days_threshold: int = 0) -> int:
+        return archive_expired_rentals(days_threshold)
+
+
+default_manager = RentalManager()
+# alias used in other modules
+rental_manager = default_manager
+

--- a/session_classifier.py
+++ b/session_classifier.py
@@ -1,0 +1,26 @@
+# -*- coding: utf-8 -*-
+"""Session classification helpers."""
+
+from constants import Constants
+
+
+class SessionClassifier:
+    """Very light session classifier used for placeholder operations."""
+
+    @staticmethod
+    def is_clean(session_string: str) -> bool:
+        """Determine if the given session can be considered clean.
+
+        The placeholder implementation simply checks for a keyword in the
+        session string. Real implementations would inspect the Telegram
+        account's history via Telethon.
+        """
+        return "clean" in session_string.lower()
+
+    @staticmethod
+    def classify(session_string: str) -> str:
+        """Return the detected session type."""
+        if SessionClassifier.is_clean(session_string):
+            return Constants.SESSION_TYPE_CLEAN
+        return Constants.SESSION_TYPE_DIRTY
+

--- a/session_manager.py
+++ b/session_manager.py
@@ -1,0 +1,129 @@
+# -*- coding: utf-8 -*-
+"""Simple session management placeholder."""
+
+import logging
+import time
+from typing import Dict, List, Optional, Tuple
+
+from constants import Constants
+
+logger = logging.getLogger(__name__)
+
+# In memory session storage for placeholder purposes
+_sessions: List[Dict[str, any]] = []
+_next_id = 1
+
+
+class Session:
+    """Represents a Telegram session entry."""
+
+    @staticmethod
+    def load_all() -> List[Dict[str, any]]:
+        """Load all sessions from storage if possible."""
+        try:
+            from db import execute_query
+
+            result = execute_query("SELECT * FROM sessions")
+            return [dict(row) for row in result] if result else []
+        except Exception:
+            # fallback to in-memory store
+            return list(_sessions)
+
+
+def get_all_sessions() -> List[Dict[str, any]]:
+    """Return all known sessions."""
+    return list(_sessions)
+
+
+async def get_session(session_type: str) -> Optional[Dict[str, any]]:
+    """Retrieve an available session of the requested type."""
+    for sess in _sessions:
+        if sess.get("type") == session_type and not sess.get("is_active"):
+            sess["is_active"] = True
+            sess["last_used"] = time.time()
+            return sess
+    return None
+
+
+def release_session(session_id: int) -> None:
+    """Mark a session as no longer active."""
+    for sess in _sessions:
+        if sess.get("id") == session_id:
+            sess["is_active"] = False
+            break
+
+
+def delete_session(session_id: int) -> Tuple[bool, str]:
+    """Remove a session from storage."""
+    global _sessions
+    count_before = len(_sessions)
+    _sessions = [s for s in _sessions if s.get("id") != session_id]
+    if len(_sessions) < count_before:
+        return True, "deleted"
+    return False, "session not found"
+
+
+def remove_inactive_sessions() -> int:
+    """Remove sessions that are not active."""
+    global _sessions
+    inactive = [s for s in _sessions if not s.get("is_active")]
+    _sessions = [s for s in _sessions if s.get("is_active")]
+    return len(inactive)
+
+
+def cleanup_invalid_sessions() -> int:
+    """Placeholder for cleaning invalid sessions."""
+    # In this simplified implementation we have nothing to do
+    return 0
+
+
+def close_all_sessions() -> None:
+    """Mark all sessions as inactive."""
+    for sess in _sessions:
+        sess["is_active"] = False
+
+
+# simple API to add sessions for placeholder/demo usage
+def _add_session(session_string: str, session_type: str = Constants.SESSION_TYPE_CLEAN) -> int:
+    global _next_id
+    sess = {
+        "id": _next_id,
+        "session_string": session_string,
+        "type": session_type,
+        "is_active": False,
+        "last_used": 0,
+    }
+    _next_id += 1
+    _sessions.append(sess)
+    return sess["id"]
+
+
+# expose a singleton-like accessor for external modules
+class SessionManager:
+    def __init__(self) -> None:
+        pass
+
+    async def get_session(self, session_type: str) -> Optional[Dict[str, any]]:
+        return await get_session(session_type)
+
+    def release_session(self, session_id: int) -> None:
+        release_session(session_id)
+
+    def get_all_sessions(self) -> List[Dict[str, any]]:
+        return get_all_sessions()
+
+    def delete_session(self, session_id: int) -> Tuple[bool, str]:
+        return delete_session(session_id)
+
+    def remove_inactive_sessions(self) -> int:
+        return remove_inactive_sessions()
+
+    def cleanup_invalid_sessions(self) -> int:
+        return cleanup_invalid_sessions()
+
+    def close_all_sessions(self) -> None:
+        close_all_sessions()
+
+
+session_manager = SessionManager()
+

--- a/settings.py
+++ b/settings.py
@@ -1,0 +1,41 @@
+# -*- coding: utf-8 -*-
+"""Minimal settings helper."""
+
+import json
+import os
+from typing import Any, Dict
+
+SETTINGS_FILE = "settings.json"
+
+
+def _load() -> Dict[str, Any]:
+    if os.path.exists(SETTINGS_FILE):
+        try:
+            with open(SETTINGS_FILE, "r", encoding="utf-8") as f:
+                return json.load(f)
+        except Exception:
+            return {}
+    return {}
+
+
+def _save(data: Dict[str, Any]) -> None:
+    with open(SETTINGS_FILE, "w", encoding="utf-8") as f:
+        json.dump(data, f, ensure_ascii=False, indent=2)
+
+
+class Settings:
+    @classmethod
+    def get(cls, key: str, default: Any = None) -> Any:
+        data = _load()
+        return data.get(key, default)
+
+    @classmethod
+    def set(cls, key: str, value: Any) -> None:
+        data = _load()
+        data[key] = value
+        _save(data)
+
+    @classmethod
+    def all(cls) -> Dict[str, Any]:
+        return _load()
+


### PR DESCRIPTION
## Summary
- add `session_manager` placeholder
- add `rental_manager` placeholder
- add simple notifications module
- add minimal `settings` helper
- add basic `SessionClassifier`

## Testing
- `python -m py_compile session_manager.py rental_manager.py notifications.py settings.py session_classifier.py`

------
https://chatgpt.com/codex/tasks/task_e_6853bda423ec8330a6d40f2aafaedd28

## Summary by Sourcery

Add placeholder modules and utilities for rental and session management, notifications, settings, and session classification

New Features:
- Introduce in-memory rental_manager placeholder with basic CRUD, status updates, expiration, and archival operations
- Introduce session_manager placeholder with in-memory and DB fallback, session acquisition, release, deletion, and cleanup utilities
- Add simple notifications module with in-memory notification storage and retrieval
- Add minimal JSON-based settings helper for persistent configuration
- Add basic SessionClassifier for clean vs. dirty session detection